### PR TITLE
Update LA course link

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ kubectl get svc  -o wide --all-namespaces
 
 # CKA Preparation Courses
 
-- [Certified Kubernetes Administrator (CKA) - Linux Academy](https://linuxacademy.com/course/cloud-native-certified-kubernetes-administrator-cka/)
+- [Certified Kubernetes Administrator (CKA) - A Cloud Guru (formerly Linux Academy)](https://acloudguru.com/course/cloud-native-certified-kubernetes-administrator-cka/)
 
 - [Kubernetes Fundamentals (LFS258) - Linux Foundation](https://training.linuxfoundation.org/training/kubernetes-fundamentals/)
 


### PR DESCRIPTION
The older Linux Academy course now redirects to A Cloud Guru as they are acquaired (it's the same course contents though).