### PR TITLE
docs: fix broken PersistentVolume tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Exam objectives that outline of the knowledge, skills and abilities that a Certi
 
     - [Kubernetes Documentation > Concepts > Storage > Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims)
 
-    - [Kubernetes Documentation > Tasks > Configure Pods and Containers > Configure a Pod to Use a PersistentVolume for Storage](https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolume)
+    - [Kubernetes Documentation > Tutorials > Configuration > Configure a Pod to Use a PersistentVolume for Storage](https://kubernetes.io/docs/tutorials/configuration/configure-persistent-volume-storage/#create-a-persistentvolume)
 
 ## Workloads & Scheduling (15%)
 


### PR DESCRIPTION
The Kubernetes docs reclassified "Configure a Pod to Use a PersistentVolume for Storage" from a Task to a Tutorial, moving it from /docs/tasks/configure-pod-container/ to
/docs/tutorials/configuration/. The page slug and
#create-a-persistentvolume anchor are unchanged.

Update the URL and the breadcrumb description to match the new location (Tutorials > Configuration).